### PR TITLE
Add default "colorimetry" view transform

### DIFF
--- a/config.ocio
+++ b/config.ocio
@@ -26,6 +26,7 @@ file_rules:
 displays:
   sRGB:
     - !<View> {name: AgX, view_transform: AgX Log View, display_colorspace: sRGB, looks: Look AgX Base, description: AgX Base Image Encoding for sRGB displays}
+    - !<View> {name: Display Native, view_transform: Colorimetry, display_colorspace: sRGB}
 
 active_displays: []
 active_views: []
@@ -39,6 +40,13 @@ looks:
 
 
 view_transforms:
+  # The first ViewTransform is the config's "default". It *must* define the relationship between the "scene" and "display" reference spaces.
+  - !<ViewTransform>
+    name: Colorimetry
+    family: Utility
+    description: Scene-reference to Display-reference bridge
+    from_scene_reference: !<BuiltinTransform> {style: IDENTITY}
+
   - !<ViewTransform>
     name: AgX Log View
     family: Log Encodings
@@ -48,12 +56,6 @@ view_transforms:
         - !<RangeTransform> {min_in_value: 0, min_out_value: 0}
         - !<MatrixTransform> {matrix: [0.842479062253094, 0.0784335999999992, 0.0792237451477643, 0, 0.0423282422610123, 0.878468636469772, 0.0791661274605434, 0, 0.0423756549057051, 0.0784336, 0.879142973793104, 0, 0, 0, 0, 1]}
         - !<AllocationTransform> {allocation: lg2, vars: [-12.47393, 7.526069]}
-
-  - !<ViewTransform>
-    name: AgX Base
-    family: Imagery
-    description: AgX Base Image Encoding
-    from_display_reference: !<LookTransform> {src: Linear BT.709, dst: AgX Log, looks: Look AgX Base}
 
 display_colorspaces:
   - !<ColorSpace>


### PR DESCRIPTION
The first view transform always defines the relationship between the scene- and display- connector spaces. In other words, whenever you transform between display color spaces and regular color spaces, the first view transform is used as a bridge between both worlds. In this case, there's no colorimetric difference between `Linear BT.709 Closed Domain` and `Linear BT.709`. Technically, both are bounded by the same half-float domain limits; and in a canonical scene -> display/view pipeline, the display color space would dictate the bounds of the closed-domain state. 

(I think you should probably add `Linear BT.709 Closed Domain` to the inactive_colorspaces list, because it doesn't serve end users to expose two functionally identical linear spaces).


I also got rid of the `AgX Base` ViewTransform, because it's just applying a look that would more appropriately be applied as part of a view. It would make more sense to use looks in view transforms if you wanted to add a "trim" between the DRT and a class of like display color spaces.



uh, I didn't actually test this, but it probably works.